### PR TITLE
typo fix in the redirect url

### DIFF
--- a/docs/v3.x/admin-panel/deploy.md
+++ b/docs/v3.x/admin-panel/deploy.md
@@ -50,5 +50,5 @@ After running `yarn build` with this configuration, the folder `build` will be c
 The administration URL will then be `http://yourfrontend.com` and every request from the panel will hit the backend at `http://yourbackend.com`.
 
 ::: tip NOTE
-If you add a path to the `url` option, it won't prefix your app. To do so, you need to also use a proxy server like Nginx. More [here](../getting-started/deployment#optional-software-guides).
+If you add a path to the `url` option, it won't prefix your app. To do so, you need to also use a proxy server like Nginx. More [here](../getting-started/deployment.html#optional-software-guides).
 :::


### PR DESCRIPTION
### What does it do?
Updated typo in redirect URL to proxy section on admin panel deployment section **NOTE**.

https://strapi.io/documentation/v3.x/admin-panel/deploy.html#deploy-the-administration-panel-on-another-server-aws-s3-azure-etc-than-the-api

### Why is it needed?

To improve the doc experience and to avoid an unnecessary 404 Not Found

### Related issue(s)/PR(s)
 
None
